### PR TITLE
Reworked schema so that 'container' section is part of env

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,16 +103,6 @@ spack:
       image: "ubuntu:18.04"
       spack: prerelease
 
-    # Provisioning is how we want to make the executables available
-    # to the user. At the moment it could either be:
-    #
-    # 1. path (implies "concretization: together", views in "opt/view")
-    # 2. modules (implies "views: None", bootstrapping module files, sourcing them on start)
-    #
-    # We can provide a verbose way to set this option to customize the defaults
-    # i.e. to install software in places that are not /opt/software etc.
-    provisioning: path
-
     # Additional system packages that are needed at runtime
     packages:
     - libgomp1
@@ -131,5 +121,5 @@ spack:
     
     labels:
       author: "Massimiliano Culpo"
-      target: "broadwell"```
+      target: "broadwell"
 ```

--- a/README.md
+++ b/README.md
@@ -84,29 +84,7 @@ configuration file. Its format is currently experimental
 and might change drastically. As an example you can check 
 out the following:
 ```yaml
-# Select the format of the recipe e.g. docker,
-# singularity or anything else that is currently supported
-format: docker
-
-# Select from a valid list of images
-base:
-  image: "ubuntu:18.04"
-  spack: prerelease
-
-# Provisioning is how we want to make the executables available
-# to the user. At the moment the only value possible is:
-#
-# 1. path (implies "concretization: together", views in "opt/view")
-provisioning: path
-
-# Additional system packages that are needed at runtime
-packages:
-- libgomp1
-
-# Manifest that describes installation and configuration.
-# This is basically a spack.yaml entry with a few field that 
-# can't be set 
-manifest:
+spack:
   specs:
   - gromacs build_type=Release 
   - mpich
@@ -115,7 +93,43 @@ manifest:
     all:
       target: [broadwell]
 
-# Any label that we want to add to the container
-labels:
-  target: "broadwell"
+  container:
+    # Select the format of the recipe e.g. docker,
+    # singularity or anything else that is currently supported
+    format: docker
+    
+    # Select from a valid list of images
+    base:
+      image: "ubuntu:18.04"
+      spack: prerelease
+
+    # Provisioning is how we want to make the executables available
+    # to the user. At the moment it could either be:
+    #
+    # 1. path (implies "concretization: together", views in "opt/view")
+    # 2. modules (implies "views: None", bootstrapping module files, sourcing them on start)
+    #
+    # We can provide a verbose way to set this option to customize the defaults
+    # i.e. to install software in places that are not /opt/software etc.
+    provisioning: path
+
+    # Additional system packages that are needed at runtime
+    packages:
+    - libgomp1
+
+    # Custom environment modifications for the runtime. These are on 
+    # top of those prescribed by package recipes.
+    environment:
+    - action: append_path
+      var: PATH
+      value: /opt/view/bin
+    - action: append_path
+      var: LD_LIBRARY_PATH
+      value: /opt/view/lib
+    - action: unset
+      var: LIBRARY_PATH
+    
+    labels:
+      author: "Massimiliano Culpo"
+      target: "broadwell"```
 ```

--- a/container/schema.py
+++ b/container/schema.py
@@ -46,12 +46,6 @@ container_schema = {
                 }
             }
         },
-        # Describes how we want to make the executables and
-        # libraries available to users.
-        'provisioning': {
-            'type': 'string',
-            'enum': ['path']
-        },
         # Additional system packages that are needed at runtime
         'packages': {
             'type': 'array',
@@ -78,7 +72,7 @@ container_schema = {
         #    'default': {},
         # }
     },
-    'required': ['format', 'base', 'provisioning']
+    'required': ['format', 'base']
 }
 
 manifest_schema['properties']['container'] = container_schema

--- a/container/schema.py
+++ b/container/schema.py
@@ -7,7 +7,7 @@ import copy
 import spack.schema.env
 
 # We need to take control of a few configuration details
-# to generate
+# to generate an image correctly
 manifest_schema = copy.deepcopy(
     spack.schema.env.schema['patternProperties']['^env|spack$']
 )
@@ -18,9 +18,10 @@ config_schema = manifest_schema['properties']['config']
 del config_schema['properties']['install_tree']
 config_schema['additionalProperties'] = False
 
-schema = {
-    '$schema': 'http://json-schema.org/schema#',
-    'title': 'File schema for container recipe generation',
+# Options that are specific to container image generation
+container = {}
+
+container_schema = {
     'type': 'object',
     'additionalProperties': False,
     'properties': {
@@ -60,7 +61,6 @@ schema = {
         },
         # The portion of Spack environment file that can be used
         # to describe what to install and how to configure it
-        'manifest': manifest_schema,
         'environment': {
             'type': 'array'
             # TODO: implement this later, it needs #spack/13357
@@ -78,5 +78,17 @@ schema = {
         #    'default': {},
         # }
     },
-    'required': ['format', 'base', 'provisioning', 'manifest']
+    'required': ['format', 'base', 'provisioning']
+}
+
+manifest_schema['properties']['container'] = container_schema
+
+schema = {
+    '$schema': 'http://json-schema.org/schema#',
+    'title': 'Spack environment file schema',
+    'type': 'object',
+    'additionalProperties': False,
+    'patternProperties': {
+        '^env|spack$': manifest_schema
+    }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,18 +10,20 @@ import spack.util.spack_yaml as syaml
 @pytest.fixture()
 def minimal_configuration():
     return {
-        'format': 'docker',
-        'base': {
-            'image': 'ubuntu:18.04',
-            'spack': 'develop'
-        },
-        'provisioning': 'path',
-        'manifest': {
+        'spack': {
             'specs': [
                 'gromacs',
                 'mpich',
                 'fftw precision=float'
-            ]
+            ],
+            'container': {
+                'format': 'docker',
+                'base': {
+                    'image': 'ubuntu:18.04',
+                    'spack': 'develop'
+                },
+                'provisioning': 'path',
+            }
         }
     }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,8 +21,7 @@ def minimal_configuration():
                 'base': {
                     'image': 'ubuntu:18.04',
                     'spack': 'develop'
-                },
-                'provisioning': 'path',
+                }
             }
         }
     }

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -9,7 +9,7 @@ from spack.extensions.container import schema
 
 def test_images_in_schema():
     allowed_images = set(
-        schema.schema['properties']['base']['properties']['image']['enum']
+        schema.container_schema['properties']['base']['properties']['image']['enum']
     )
     images_in_json = set(x for x in images.data())
     assert images_in_json == allowed_images


### PR DESCRIPTION
This PR implements the modifications that we discussed to have the attributes related to the generation of container images under `spack:container`. You can have a look at the result by viewing the `README.md` in this branch.

Overall I would lean towards the previous version (the one currently in `master`) mainly because composing a `spack.yaml` into a new YAML file seems preferable to extending it with other attributes.  

The main drawback I see is that extending the current YAML file with new attributes requires to think about what are the interactions among them. That adds complexity to the code and this complexity:
1. Increases the more attributes we add
2. Makes the code more coupled

To give a concrete example, it's unclear to me what would be the interaction of the `container` attribute with e.g. `gitlab_ci` or `cdash`:
1. How should Spack behave when any combination of these attributes is present?
2. Would we ever have a case in which the `spack.yaml` is in an inconsistent state because some values in an attribute imply a constraint on other values in another attribute?

Composing the `spack.yaml` into another YAML file avoids this issue, since at that point the enclosing context makes clear what we want to do with the software that is listed for installation. I understand that for a user it might be less convenient to have separate YAML files for each operation but I'm not sure if having more and more sections in the same file would be better in the end.

@tgamblin @becker33 @scheibelp @tldahlgren