### PR TITLE
Added all the images of Spack that are on Dockerhub

### DIFF
--- a/container/schema.py
+++ b/container/schema.py
@@ -37,11 +37,11 @@ schema = {
             'properties': {
                 'image': {
                     'type': 'string',
-                    'enum': ['ubuntu:18.04']
+                    'enum': ['ubuntu:18.04', 'ubuntu:16.04', 'centos:7', 'centos:6']
                 },
                 'spack': {
                     'type': 'string',
-                    'enum': ['develop', 'prerelease']
+                    'enum': ['develop', 'prerelease', '0.13.2']
                 }
             }
         },

--- a/resources/images.json
+++ b/resources/images.json
@@ -9,5 +9,36 @@
       "develop": "latest",
       "prerelease": "prerelease"
     }
+  },
+  "ubuntu:16.04": {
+    "update": "apt-get -yqq update && apt-get -yqq upgrade",
+    "install": "apt-get -yqq install",
+    "clean": "rm -rf /var/lib/apt/lists/*",
+    "environment": [],
+    "build": "spack/ubuntu-xenial",
+    "build_tags": {
+      "develop": "latest",
+      "0.13.2": "0.13.2"
+    }
+  },
+  "centos:7": {
+    "update": "yum update -y && yum install -y epel-release && yum update -y",
+    "install": "yum install -y",
+    "clean": "rm -rf /var/cache/yum  && yum clean all",
+    "environment": [],
+    "build": "spack/centos7",
+    "build_tags": {
+      "develop": "latest"
+    }
+  },
+  "centos:6": {
+    "update": "yum update -y && yum install -y epel-release && yum update -y",
+    "install": "yum install -y",
+    "clean": "rm -rf /var/cache/yum  && yum clean all",
+    "environment": [],
+    "build": "spack/centos6",
+    "build_tags": {
+      "develop": "latest"
+    }
   }
 }

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -7,7 +7,11 @@ RUN mkdir {{ paths.environment }} \
 {{ manifest }} > {{ paths.environment }}/spack.yaml
 
 # Install the software, remove unecessary deps and strip executables
+{% if build.tag == 'prerelease' %}
 RUN cd {{ paths.environment }} && spack install && spack autoremove -y
+{% else %}
+RUN cd {{ paths.environment }} && spack install
+{% endif %}
 RUN cd {{ paths.view }}/bin && strip -s * || exit 0
 RUN cd {{ paths.view }}/lib && strip -s * || exit 0
 

--- a/templates/singularity.def
+++ b/templates/singularity.def
@@ -12,7 +12,9 @@ EOF
   # Install all the required software
   . /opt/spack/share/spack/setup-env.sh
   spack install
+{% if build.tag == 'prerelease' %}
   spack autoremove -y
+{% endif %}
   spack env activate --sh -d . >> /etc/profile.d/z10_spack_environment.sh
 
   # Turn soft links into hard links to work-around a known issue:


### PR DESCRIPTION
Spack currently provides ready-to-go images for different OSes:
- Ubuntu 18.04
- Ubuntu 16.04
- CentOS 6
- CentOS 7

Here we add information to generate a container image starting from any of the bases above